### PR TITLE
[10.0][IMP] Improve index recompute (exceed cpu time limit if too much records)

### DIFF
--- a/connector_search_engine/models/se_binding.py
+++ b/connector_search_engine/models/se_binding.py
@@ -86,7 +86,8 @@ class SeBinding(models.AbstractModel):
         description = _(
             "Recompute %s json and check if need update" % self._name
         )
-        for record in self:
+        # The job creation with tracking is very costly. So disable it.
+        for record in self.with_context(tracking_disable=True):
             record.with_delay(description=description).recompute_json(
                 force_export=force_export
             )

--- a/connector_search_engine/models/se_index.py
+++ b/connector_search_engine/models/se_index.py
@@ -73,10 +73,16 @@ class SeIndex(models.Model):
         return self.recompute_all_binding(force_export=True)
 
     def recompute_all_binding(self, force_export=False):
-        for record in self:
-            binding_obj = self.env[record.model_id.model]
-            for binding in binding_obj.search([("index_id", "=", record.id)]):
-                binding._jobify_recompute_json(force_export=force_export)
+        target_models = self.mapped("model_id.model")
+        for target_model in target_models:
+            indexes = self.filtered(
+                lambda r, m=target_model: r.model_id.model == m
+            )
+            bindings = self.env[target_model].search(
+                [("index_id", "in", indexes.ids)]
+            )
+            if bindings:
+                bindings._jobify_recompute_json(force_export=force_export)
         return True
 
     @api.depends("lang_id", "model_id", "backend_id.name")


### PR DESCRIPTION
**Issue:**
In case of big database, recompute can take a long time and exceed the cpu time limit (from odoo config file).

**Fix:**

- Improve the `recompute_all_binding(...)` by doing less `search`.
- Disable tracking to create sub-jobs (tracking cost a lot about perf)