### PR TITLE
[12.0] connector_elasticsearch: config index is required only for elasticsearch

### DIFF
--- a/connector_elasticsearch/models/se_index.py
+++ b/connector_elasticsearch/models/se_index.py
@@ -1,7 +1,8 @@
 # Copyright 2019 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class SeIndex(models.Model):
@@ -14,5 +15,15 @@ class SeIndex(models.Model):
         help="Elasticseacrh index definition (see https://www.elastic.co/"
         "guide/en/elasticsearch/reference/current/"
         "indices-create-index.html)",
-        required=True,
     )
+
+    @api.constrains("config_id", "backend_id")
+    def _check_config_id_required(self):
+        for rec in self:
+            if (
+                rec.backend_id.specific_model == "se.backend.elasticsearch"
+                and not rec.config_id
+            ):
+                raise ValidationError(
+                    _("An index definition is rquired for elasticsearch")
+                )

--- a/connector_elasticsearch/readme/HISTORY.rst
+++ b/connector_elasticsearch/readme/HISTORY.rst
@@ -1,0 +1,6 @@
+10.0.?.?.? (unreleased)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* connector_elasticsearch: Makes the config on index required only if the
+  index is linked to an elastisearch backend. This change allows the usage
+  of algolia search engine at the same time as elasticsearch.

--- a/connector_elasticsearch/readme/HISTORY.rst
+++ b/connector_elasticsearch/readme/HISTORY.rst
@@ -1,4 +1,4 @@
-10.0.?.?.? (unreleased)
+12.0.?.?.? (unreleased)
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 * connector_elasticsearch: Makes the config on index required only if the

--- a/connector_elasticsearch/tests/test_connector_elasticsearch.py
+++ b/connector_elasticsearch/tests/test_connector_elasticsearch.py
@@ -4,6 +4,7 @@ import json
 from time import sleep
 
 from odoo import exceptions
+from odoo.addons.connector_search_engine.tests.models import SeBackendFake
 from odoo.addons.connector_search_engine.tests.test_all import (
     TestBindingIndexBase,
 )
@@ -17,13 +18,18 @@ class TestConnectorElasticsearch(VCRMixin, TestBindingIndexBase):
         super().setUpClass()
         cls.backend_specific = cls.env.ref("connector_elasticsearch.backend_1")
         cls.backend = cls.backend_specific.se_backend_id
-        cls.exporter = cls.env.ref("base_jsonify.ir_exp_partner")
         cls.se_index_model = cls.env["se.index"]
         cls.setup_records()
         with cls.backend_specific.work_on(
             "se.index", index=cls.se_index
         ) as work:
             cls.adapter = work.component(usage="se.backend.adapter")
+        SeBackendFake._test_setup_model(cls.env)
+        cls.fake_backend_model = cls.env[SeBackendFake._name]
+        cls.fake_backend_specific = cls.fake_backend_model.create(
+            {"name": "Fake SE"}
+        )
+        cls.fake_backend = cls.fake_backend_specific.se_backend_id
 
     def _get_vcr_kwargs(self, **kwargs):
         return {
@@ -54,7 +60,7 @@ class TestConnectorElasticsearch(VCRMixin, TestBindingIndexBase):
         self.partner_binding.sync_state = "to_update"
         with self.assertRaises(exceptions.UserError) as err:
             self.se_index.batch_export()
-            self.assertIn("The key objectID is missing in", err.exception.name)
+        self.assertIn("The key objectID is missing in", err.exception.name)
 
     def test_index_adapter(self):
         # Set partner to be updated with fake vals in data
@@ -104,6 +110,15 @@ class TestConnectorElasticsearch(VCRMixin, TestBindingIndexBase):
                 "body": {"mappings": {"new_doc_type": {}}},
             }
         )
+
+    def test_index_config_required(self):
+        with self.assertRaises(ValidationError), self.env.cr.savepoint():
+            self.se_index.config_id = False
+        # the config is anlyt required for elastc...
+        self.se_index.backend_id = self.fake_backend
+        self.se_index.config_id = False
+        with self.assertRaises(ValidationError), self.env.cr.savepoint():
+            self.se_index.backend_id = self.backend
 
     def test_index_config_as_str(self):
         self.se_config.write(


### PR DESCRIPTION
forward port of #8