### PR TITLE
[12.0][FIX] connector_elasticsearch: Uses requests as trasnport layer by de…

### DIFF
--- a/connector_elasticsearch/__manifest__.py
+++ b/connector_elasticsearch/__manifest__.py
@@ -23,5 +23,5 @@
         "views/se_menu.xml",
     ],
     "demo": ["demo/backend_demo.xml"],
-    "external_dependencies": {"python": ["elasticsearch"]},
+    "external_dependencies": {"python": ["elasticsearch", "requests"]},
 }

--- a/connector_elasticsearch/components/adapter.py
+++ b/connector_elasticsearch/components/adapter.py
@@ -25,10 +25,17 @@ class ElasticsearchAdapter(Component):
     def _index_name(self):
         return self.work.index.name.lower()
 
+    @property
+    def _es_connection_class(self):
+        return elasticsearch.RequestsHttpConnection
+
     def _get_es_client(self):
         backend = self.backend_record
 
-        es = elasticsearch.Elasticsearch([backend.es_server_host])
+        es = elasticsearch.Elasticsearch(
+            [backend.es_server_host],
+            connection_class=self._es_connection_class,
+        )
 
         if not es.ping():  # pragma: no cover
             raise ValueError("Connect Exception with elasticsearch")


### PR DESCRIPTION
…fault

 * [ ] forward port of #24

By default, the elastic search client uses the urllib3 transport which checks the certificates with the bundle provided by certifi.

However, in some cases, the certificate used is not available in certifi.

The elasticsearch client can also use requests as a transport layer. Requests is also based on certifi, but has the advantage that it can also be configured with the environment variable.

export REQUESTS_CA_CA_BUNDLE=/etc/ssl/certs/ca-bundle.crt

This change allows you to manage certificates at the system level, which is cleaner and simpler than adding configuration options to the code.