### PR TITLE
[12.0][FIX] connector_elasticsearch: Failed to create index due to nu…

### DIFF
--- a/connector_elasticsearch/models/se_index_config.py
+++ b/connector_elasticsearch/models/se_index_config.py
@@ -18,6 +18,18 @@ class SeIndexConfig(models.Model):
         compute="_compute_body_str", inverse="_inverse_body_str"
     )
 
+    @api.model
+    def create(self, values):
+        # For new record creation, the inverse function for `body_str` is 
+        # called after the record is inserted into database. The field 
+        # `body` would be empty, and a validation error will pop up as field 
+        # `body` is required. The solution is to override create function, 
+        # and initialize field `body` based on field `body_str`.
+        if 'body' not in values and 'body_str' in values:
+            values['body'] = json.loads(values['body_str'])
+
+        return super(SeIndexConfig, self).create(values)
+
     @api.multi
     @api.depends("body")
     def _compute_body_str(self):


### PR DESCRIPTION
Dear reviewers and all,

Environment: odoo 12 community, OSX, Python 3.6.5

Problem: I installed elasticsearch connector and failed to create an index using the form due to validation error (`body` is empty and is required)

Analysis: inverse function for `body_str` is not called, so `body` is empty.

Solution: overriding create function to initialize `body` if it is empty.

Thanks,
Lyon