### PR TITLE
[12.0] Fix missing default values when creating an index.

### DIFF
--- a/connector_elasticsearch/models/se_index_config.py
+++ b/connector_elasticsearch/models/se_index_config.py
@@ -11,22 +11,20 @@ class SeIndexConfig(models.Model):
     _description = "Elasticsearch index configuration"
 
     name = fields.Char(required=True)
-    body = fields.Serialized(required=True)
+    body = fields.Serialized(required=True, default={})
     # This field is used since no widget exists to edit a serialized field
     # into the web fontend
-    body_str = fields.Text(compute="_compute_body_str", inverse="_inverse_body_str")
+    body_str = fields.Text(
+        compute="_compute_body_str", inverse="_inverse_body_str", default="{}"
+    )
 
     @api.multi
     @api.depends("body")
     def _compute_body_str(self):
         for rec in self:
-            if rec.body:
-                rec.body_str = json.dumps(rec.body)
+            rec.body_str = json.dumps(rec.body)
 
     @api.multi
     def _inverse_body_str(self):
         for rec in self:
-            data = None
-            if rec.body_str:
-                data = json.loads(rec.body_str)
-            rec.body = data
+            rec.body = json.loads(rec.body_str or "{}")

--- a/connector_elasticsearch/readme/CONTRIBUTORS.rst
+++ b/connector_elasticsearch/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Laurent Corron <laurentcorron@gmail.com>
 * Laurent Mignon <laurent.mignon@acsone.eu>
+* Raphaël Reverdy <raphael.reverdy@akretion.com>


### PR DESCRIPTION
1) Fix bug if body = {} then edit, body_str = False
so if you touch nothing you can't save
2) It's good to have default values. While we
don't have good interface for this model,"{}" hints
the user that json is expected and it can't be empty.