### PR TITLE
[13.0][FIX] connector_search_engine: Adapt compute to v13

### DIFF
--- a/connector_search_engine/models/se_index.py
+++ b/connector_search_engine/models/se_index.py
@@ -97,6 +97,8 @@ class SeIndex(models.Model):
                         rec.lang_id.code,
                     ]
                 )
+            else:
+                rec.name = ""
 
     def force_batch_export(self):
         self.ensure_one()


### PR DESCRIPTION
While configuring Search Engine Filters _compute_name does not retrieve any value
![image](https://user-images.githubusercontent.com/32061121/80495845-b84ed680-8968-11ea-8de2-94cee2104e40.png)
