### PR TITLE
se.binding: add data_display, compute size for algolia index binding

### DIFF
--- a/connector_algolia/models/__init__.py
+++ b/connector_algolia/models/__init__.py
@@ -1,2 +1,3 @@
 from . import se_backend_algolia
 from . import se_index
+from . import se_binding

--- a/connector_algolia/models/se_binding.py
+++ b/connector_algolia/models/se_binding.py
@@ -1,0 +1,29 @@
+# Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import json
+
+from odoo import api, fields, models
+from odoo.tools import human_size
+
+
+class SeBinding(models.AbstractModel):
+    _inherit = "se.binding"
+
+    data_size = fields.Char(
+        string="Index record size",
+        compute="_compute_data_size",
+        store=True,
+        help="Computed size of the index. "
+        "Algolia limits record size to 10KB "
+        "and exports fail if your record exceeds the quota.",
+    )
+
+    @api.depends("data")
+    def _compute_data_size(self):
+        for rec in self:
+            rec.data_size = human_size(rec._get_bytes_size())
+
+    def _get_bytes_size(self):
+        return len(json.dumps(self.data or {}))

--- a/connector_algolia/tests/test_se_algolia.py
+++ b/connector_algolia/tests/test_se_algolia.py
@@ -8,6 +8,7 @@ from time import sleep
 from vcr_unittest import VCRMixin
 
 from odoo import exceptions
+from odoo.tools import human_size
 
 from odoo.addons.connector_search_engine.tests.test_all import TestBindingIndexBase
 
@@ -135,3 +136,12 @@ class TestAlgoliaBackend(VCRMixin, TestBindingIndexBase):
             sleep(2)
         res = [x for x in self.adapter.each()]
         self.assertEqual(res, data)
+
+    def test_index_size(self):
+        self.assertTrue(self.partner_binding.data)
+        self.assertEqual(
+            self.partner_binding.data_size,
+            human_size(self.partner_binding._get_bytes_size()),
+        )
+        self.partner_binding.data = {}
+        self.assertEqual(self.partner_binding.data_size, "2.00 bytes")

--- a/connector_search_engine/models/se_binding.py
+++ b/connector_search_engine/models/se_binding.py
@@ -1,6 +1,8 @@
 # Copyright 2013 Akretion (http://www.akretion.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import json
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
@@ -35,7 +37,16 @@ class SeBinding(models.AbstractModel):
     date_modified = fields.Date(readonly=True)
     date_syncronized = fields.Date(readonly=True)
     data = fields.Serialized()
+    data_display = fields.Text(
+        compute="_compute_data_display",
+        help="Include this in debug mode to be able to inspect index data.",
+    )
     active = fields.Boolean(string="Active", default=True)
+
+    @api.depends("data")
+    def _compute_data_display(self):
+        for rec in self:
+            rec.data_display = json.dumps(rec.data, sort_keys=True, indent=4)
 
     def get_export_data(self):
         """Public method to retrieve export data."""


### PR DESCRIPTION
It's very handy to be able to inspect indexed data
even before pushing it to the search engine.

You can include 'data_display' in a custom view (debug mode recommended)
to see what gets indexed.

Algolia limits record size to 10KB and exports fail if your record exceeds the quota.
With this new field you are able to check the size straight from odoo.