### PR TITLE
[13.0] [FIX] connector_search_engine: always assign value in name computation

### DIFF
--- a/connector_search_engine/models/se_index.py
+++ b/connector_search_engine/models/se_index.py
@@ -97,6 +97,8 @@ class SeIndex(models.Model):
                         rec.lang_id.code,
                     ]
                 )
+            else:
+                rec.name = False
 
     def force_batch_export(self):
         self.ensure_one()


### PR DESCRIPTION
Avoid an error when the name cannot be computed.