### PR TITLE
[13.0] [FIX] connector_search_engine: export cron priority

### DIFF
--- a/connector_search_engine/data/ir_cron.xml
+++ b/connector_search_engine/data/ir_cron.xml
@@ -25,6 +25,7 @@
         <field name="model_id" ref="model_se_index" />
         <field name="state">code</field>
         <field name="code">model.generate_batch_export_per_index()</field>
+        <field name="priority" eval="6" />
     </record>
     <record forcecreate="True" id="ir_cron_export_settings" model="ir.cron">
         <field name="name">Search engine: Export settings for all indexes</field>


### PR DESCRIPTION
Makes sure the export cron runs always after the recompute cron.[In Odoo, crons are sorted by priority only](https://github.com/odoo/odoo/blob/13.0/odoo/addons/base/models/ir_cron.py#L198).