### PR TITLE
[13.0][IMP] connector_search_engine: Export only active binding records

### DIFF
--- a/connector_search_engine/models/se_index.py
+++ b/connector_search_engine/models/se_index.py
@@ -131,7 +131,7 @@ class SeIndex(models.Model):
         self.ensure_one()
         domain = self._get_domain_for_exporting_binding(force_export)
         binding_obj = self.env[self.model_id.model]
-        bindings = binding_obj.with_context(active_test=False).search(domain)
+        bindings = binding_obj.search(domain)
         bindings_count = len(bindings)
         while bindings:
             processing = bindings[0 : self.batch_size]  # noqa: E203


### PR DESCRIPTION
Is there any use case that required the export of not active records? I'm having troubles when customers are preparing record data to export, and they achieve records while they are performing the changes.

@rousseldenis @simahawk @Cedric-Pigeon 