### PR TITLE
[13.0][IMP] connector_elasticsearch: Add API key support to Elasticsearch connector

### DIFF
--- a/connector_elasticsearch/README.rst
+++ b/connector_elasticsearch/README.rst
@@ -69,6 +69,7 @@ Contributors
 * Laurent Corron <laurentcorron@gmail.com>
 * Laurent Mignon <laurent.mignon@acsone.eu>
 * Raphaël Reverdy <raphael.reverdy@akretion.com>
+* Dawson Coleman <dcoleman@lulzbot.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/connector_elasticsearch/components/adapter.py
+++ b/connector_elasticsearch/components/adapter.py
@@ -33,7 +33,8 @@ class ElasticsearchAdapter(Component):
         backend = self.backend_record
 
         es = elasticsearch.Elasticsearch(
-            [backend.es_server_host], connection_class=self._es_connection_class
+            [backend.es_server_host], connection_class=self._es_connection_class,
+            api_key=(backend.api_key_id, backend.api_key) if backend.api_key_id and backend.api_key else None
         )
 
         if not es.ping():  # pragma: no cover

--- a/connector_elasticsearch/components/adapter.py
+++ b/connector_elasticsearch/components/adapter.py
@@ -32,12 +32,13 @@ class ElasticsearchAdapter(Component):
     def _get_es_client(self):
         backend = self.backend_record
 
+        api_key = None
+        if backend.api_key_id and backend.api_key:
+            api_key = (backend.api_key_id, backend.api_key)
         es = elasticsearch.Elasticsearch(
             [backend.es_server_host],
             connection_class=self._es_connection_class,
-            api_key=(backend.api_key_id, backend.api_key)
-            if backend.api_key_id and backend.api_key
-            else None,
+            api_key=api_key,
         )
 
         if not es.ping():  # pragma: no cover

--- a/connector_elasticsearch/components/adapter.py
+++ b/connector_elasticsearch/components/adapter.py
@@ -33,8 +33,11 @@ class ElasticsearchAdapter(Component):
         backend = self.backend_record
 
         es = elasticsearch.Elasticsearch(
-            [backend.es_server_host], connection_class=self._es_connection_class,
-            api_key=(backend.api_key_id, backend.api_key) if backend.api_key_id and backend.api_key else None
+            [backend.es_server_host],
+            connection_class=self._es_connection_class,
+            api_key=(backend.api_key_id, backend.api_key)
+            if backend.api_key_id and backend.api_key
+            else None,
         )
 
         if not es.ping():  # pragma: no cover

--- a/connector_elasticsearch/models/se_backend_elasticsearch.py
+++ b/connector_elasticsearch/models/se_backend_elasticsearch.py
@@ -25,6 +25,8 @@ class SeBackendElasticsearch(models.Model):
     tech_name = fields.Char(
         related="se_backend_id.tech_name", store=True, readonly=False
     )
+    api_key_id = fields.Char(help="Elasticsearch Api Key ID", string="Api Key ID")
+    api_key = fields.Char(help="Elasticsearch Api Key")
 
     @property
     def _server_env_fields(self):

--- a/connector_elasticsearch/views/se_backend_elasticsearch.xml
+++ b/connector_elasticsearch/views/se_backend_elasticsearch.xml
@@ -18,6 +18,8 @@
                                 name="es_server_host"
                                 placeholder="http://127.0.0.1:9200"
                             />
+                            <field name="api_key_id"/>
+                            <field name="api_key" />
                         </group>
                     </group>
                     <group name="index" string="Index">

--- a/connector_elasticsearch/views/se_backend_elasticsearch.xml
+++ b/connector_elasticsearch/views/se_backend_elasticsearch.xml
@@ -18,7 +18,7 @@
                                 name="es_server_host"
                                 placeholder="http://127.0.0.1:9200"
                             />
-                            <field name="api_key_id"/>
+                            <field name="api_key_id" />
                             <field name="api_key" />
                         </group>
                     </group>


### PR DESCRIPTION
Allows the usage of an Elasticsearch API key, enabling the module to work with X-Pack security.