### PR TITLE
[FIX] connector_elasticsearch: ignore missing documents in delete

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
   - id: mixed-line-ending
     args: ["--fix=lf"]
 - repo: https://github.com/pre-commit/mirrors-pylint
-  rev: v2.3.1
+  rev: v2.3.0
   hooks:
   - id: pylint
     name: pylint with optional checks

--- a/connector_elasticsearch/components/adapter.py
+++ b/connector_elasticsearch/components/adapter.py
@@ -17,6 +17,12 @@ except ImportError:
     _logger.debug("Can not import elasticsearch")
 
 
+def _is_delete_nonexistent_documents(elastic_exception):
+    """True iff all errors in this exception are deleting a nonexisting document."""
+    b = lambda d: "delete" in d and d["delete"]["status"] == 404  # noqa
+    return all(b(error) for error in elastic_exception.errors)
+
+
 class ElasticsearchAdapter(Component):
     _name = "elasticsearch.adapter"
     _inherit = ["se.backend.adapter", "elasticsearch.se.connector"]
@@ -79,10 +85,15 @@ class ElasticsearchAdapter(Component):
                 "_id": binding_id,
             }
             dataforbulk.append(action)
-
-        res = elasticsearch.helpers.bulk(es, dataforbulk)
-        # checks if number of indexed object and object in datas are equal
-        return len(binding_ids) - res[0] == 0
+        try:
+            elasticsearch.helpers.bulk(es, dataforbulk)
+        except elasticsearch.helpers.errors.BulkIndexError as e:
+            # if the document we are trying to delete does not exist,
+            # we can consider deletion a success (there is nothing to do).
+            if not _is_delete_nonexistent_documents(e):
+                raise e
+            msg = "Trying to delete non-existent documents. Ignored: %s"
+            _logger.info(msg, e)
 
     def clear(self):
         es = self._get_es_client()

--- a/connector_elasticsearch/tests/cassettes/TestConnectorElasticsearch.test_index_adapter_delete_nonexisting_documents.yaml
+++ b/connector_elasticsearch/tests/cassettes/TestConnectorElasticsearch.test_index_adapter_delete_nonexisting_documents.yaml
@@ -1,0 +1,90 @@
+interactions:
+- request:
+    body: null
+    headers:
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.10.1 (Python 3.6.12)
+    method: HEAD
+    uri: http://elastic:9200/
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '542'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.10.1 (Python 3.6.12)
+    method: HEAD
+    uri: http://elastic:9200/demo_elasticsearch_backend_res_partner_binding_fake_en_us
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '671'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: '{}'
+    headers:
+      Content-Length:
+      - '2'
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.10.1 (Python 3.6.12)
+    method: PUT
+    uri: http://elastic:9200/demo_elasticsearch_backend_res_partner_binding_fake_en_us
+  response:
+    body:
+      string: '{"acknowledged":true,"shards_acknowledged":true,"index":"demo_elasticsearch_backend_res_partner_binding_fake_en_us"}'
+    headers:
+      content-length:
+      - '116'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"delete":{"_id":"donotexist","_index":"demo_elasticsearch_backend_res_partner_binding_fake_en_us"}}
+
+      {"delete":{"_id":"donotexisteither","_index":"demo_elasticsearch_backend_res_partner_binding_fake_en_us"}}
+
+      '
+    headers:
+      Content-Length:
+      - '208'
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.10.1 (Python 3.6.12)
+    method: POST
+    uri: http://elastic:9200/_bulk
+  response:
+    body:
+      string: '{"took":155,"errors":false,"items":[{"delete":{"_index":"demo_elasticsearch_backend_res_partner_binding_fake_en_us","_type":"_doc","_id":"donotexist","_version":1,"result":"not_found","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":404}},{"delete":{"_index":"demo_elasticsearch_backend_res_partner_binding_fake_en_us","_type":"_doc","_id":"donotexisteither","_version":1,"result":"not_found","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1,"status":404}}]}'
+    headers:
+      content-length:
+      - '525'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
As ce6c775d375a states, delete is done in the same transaction as the export.
This means that an exception during delete fails the whole job.
If a document does not exist in the index, as far as delete is concerned,
the job is done. So we ignore these exceptions.
Also: there are plenty of trivial reasons for which this might happen.
The error is nonetheless logged.