### PR TITLE
[14.0][FIX] Remove index_prefix_name from abstract model

### DIFF
--- a/connector_search_engine/models/se_backend_spec_abstract.py
+++ b/connector_search_engine/models/se_backend_spec_abstract.py
@@ -29,18 +29,6 @@ class SeBackendSpecAbstract(models.AbstractModel):
         delegate=True,
         required=True,
     )
-    # This must be re-defined here because
-    # we want to be able to set the prefix based on the specific search engine.
-    index_prefix_name = fields.Char(
-        related="se_backend_id.index_prefix_name",
-        readonly=False,
-    )
-
-    @property
-    def _server_env_fields(self):
-        # We need this because calling `super` in the specific backend
-        # won't call the property from `se.backend` because of `inherits` behavior.
-        return {"index_prefix_name": {}}
 
     @api.model
     def create(self, vals):


### PR DESCRIPTION
When installing the optional module server_environment_data_encryption.

If you create an elastic backend and save it (without creating index) the index_prefix_name is correctly saved inside a data_encrypted object linked to the se.backend.

Then if you add an index, it will try to read the index_prefix_name on the related "se.backend.elastic" and break everything (index name are always empty).

I would like to understand why we have to redifine the field index_prefix_name on the se.backend.spec.abstract.


I will try to spend more time on it (for now I can live with my fix). 

@simahawk can you try if you still have the issue on your side if I remove the code on V14? If yes how can I reproduce it ?

