### PR TITLE
[14.0] c_search_engine: fix lang agnostic name compute

### DIFF
--- a/connector_search_engine/models/se_index.py
+++ b/connector_search_engine/models/se_index.py
@@ -89,7 +89,7 @@ class SeIndex(models.Model):
         for rec in self:
             backend = rec.backend_id
             name = ""
-            if rec.lang_id and rec.model_id and backend.index_prefix_name:
+            if rec.model_id and backend.index_prefix_name:
                 bits = [
                     backend.index_prefix_name,
                     backend._normalize_tech_name(rec.model_id.name or ""),

--- a/connector_search_engine/tests/test_all.py
+++ b/connector_search_engine/tests/test_all.py
@@ -152,6 +152,9 @@ class TestBindingIndex(TestBindingIndexBaseFake):
         # TODO: not sure why this is needed here
         self.se_index.invalidate_cache()
         self.assertEqual(self.se_index.name, "foo_baz_res_partner_binding_fake_en_US")
+        self.se_index.lang_id = False
+        self.se_index.invalidate_cache()
+        self.assertEqual(self.se_index.name, "foo_baz_res_partner_binding_fake")
 
     def test_changing_model_remove_exporter(self):
         res = self.se_index.onchange_model_id()


### PR DESCRIPTION
I missed test coverage for lang agnostic index name and it stroke me back :sweat_smile: 

ref: 624