### PR TITLE
[14.0] c_search_engine: allow index custom name

### DIFF
--- a/connector_search_engine/tests/test_all.py
+++ b/connector_search_engine/tests/test_all.py
@@ -156,6 +156,12 @@ class TestBindingIndex(TestBindingIndexBaseFake):
         self.se_index.invalidate_cache()
         self.assertEqual(self.se_index.name, "foo_baz_res_partner_binding_fake")
 
+    def test_index_custom_name(self):
+        self.se_index.custom_tech_name = "something meaningful for me"
+        self.assertEqual(
+            self.se_index.name, "fake_se_something_meaningful_for_me_en_US"
+        )
+
     def test_changing_model_remove_exporter(self):
         res = self.se_index.onchange_model_id()
         self.assertEqual(len(self.se_index.exporter_id), 0)

--- a/connector_search_engine/views/se_backend.xml
+++ b/connector_search_engine/views/se_backend.xml
@@ -22,6 +22,7 @@
                     <group name="index" string="Index">
                         <field name="index_ids" nolabel="1">
                             <tree string="Index" editable="bottom">
+                                <field name="custom_tech_name" optional="hide" />
                                 <field name="name" />
                                 <field name="lang_id" />
                                 <field name="model_id" />


### PR DESCRIPTION
- [x] Depends on / includes #90 to avoid useless conflicts. Only the last commit is relevant.

Sometimes for functional reasons you want to take control of indexes' name.
This is now possible w/ the field 'custom_tech_name' (hidden by default).
The value of this field, if populated, will be used to compose the index name
instead of using the model name.

