### PR TITLE
[14.0] c_search_engine: fix base adapter

### DIFF
--- a/connector_search_engine/components/adapter.py
+++ b/connector_search_engine/components/adapter.py
@@ -16,19 +16,19 @@ class SeAdapter(AbstractComponent):
         return True  # pragma: no cover
 
     def index(self, datas):
-        return NotImplemented  # pragma: no cover
+        raise NotImplementedError()
 
     def delete(self, binding_ids):
-        return NotImplemented  # pragma: no cover
+        raise NotImplementedError()
 
     def clear(self):
-        return NotImplemented  # pragma: no cover
+        raise NotImplementedError()
 
     def each(self):
-        return NotImplemented  # pragma: no cover
+        raise NotImplementedError()
 
     def settings(self, force=False):
-        return NotImplemented  # pragma: no cover
+        raise NotImplementedError()
 
     def external_id(self, record):
         return record[self._record_id_key]


### PR DESCRIPTION
Not implemented methods should raise proper error
otherwise nobody will notice they are not implemented.