### PR TITLE
[FIX] _make_name method for se_index

### DIFF
--- a/connector_search_engine/models/se_index.py
+++ b/connector_search_engine/models/se_index.py
@@ -103,7 +103,7 @@ class SeIndex(models.Model):
         backend = self.backend_id
         tech_name = self._make_tech_name()
         if tech_name:
-            bits = [backend.index_prefix_name, tech_name]
+            bits = [backend.index_prefix_name or "", tech_name]
             if self.lang_id:
                 bits.append(self.lang_id.code)
             name = "_".join(bits)


### PR DESCRIPTION
When creating a new elasticsearch index from Odoo, the index name is automatically composed from the backend_id.index_prefix_name and the tech_name.
But if the backend_id is not filled, it generates an error because backend_id.index_prefix_name returns False instead of ' '.