### PR TITLE
[FIX] connector_search_engine: Set sync_state to 'to_update' when reactivating an inactive binding

### DIFF
--- a/connector_search_engine/models/se_binding.py
+++ b/connector_search_engine/models/se_binding.py
@@ -72,7 +72,7 @@ class SeBinding(models.AbstractModel):
 
     def write(self, vals):
         not_new = self.browse()
-        if "active" in vals and not vals["active"]:
+        if "active" in vals:
             not_new = self.filtered(lambda x: x.sync_state != "new")
             new_vals = vals.copy()
             new_vals["sync_state"] = "to_update"

--- a/connector_search_engine/tests/test_all.py
+++ b/connector_search_engine/tests/test_all.py
@@ -316,6 +316,11 @@ class TestBindingIndex(TestBindingIndexBaseFake):
         self.partner_binding.active = False
         self.assertEqual(self.partner_binding.sync_state, "to_update")
 
+    def test_inactive_binding_change_state_to_active(self):
+        self.partner_binding.sync_state = "done"
+        self.partner_binding.active = True
+        self.assertEqual(self.partner_binding.sync_state, "to_update")
+
     def test_inactive_new_binding_do_not_change_state(self):
         self.partner_binding.sync_state = "new"
         self.partner_binding.active = False


### PR DESCRIPTION
When a binding is deactivated, its state is set to `to_update` but when it's reactivated nothing happens.

This PR sets the state to `to_update` when the binding is set to active again.
