### PR TITLE
[14.0][FIX] connector_search_engine fix make_name.

### DIFF
--- a/connector_search_engine/models/se_index.py
+++ b/connector_search_engine/models/se_index.py
@@ -112,7 +112,7 @@ class SeIndex(models.Model):
             bits = [backend.index_prefix_name, tech_name]
             if self.lang_id:
                 bits.append(self.lang_id.code)
-            name = "_".join(bits)
+            name = "_".join([b for b in bits if b])
         return name
 
     def _make_tech_name(self):


### PR DESCRIPTION
When there are empty values into bits `list` (so `False`), it's not possible to build a `str` (that raise an exception). So check if there is a value to join `str` together