### PR TITLE
[14.0] Fix missing config_id from views

### DIFF
--- a/connector_elasticsearch/models/se_index.py
+++ b/connector_elasticsearch/models/se_index.py
@@ -1,19 +1,13 @@
 # Copyright 2019 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, api, fields, models
+from odoo import _, api, models
 from odoo.exceptions import ValidationError
 
 
 class SeIndex(models.Model):
 
     _inherit = "se.index"
-
-    config_id = fields.Many2one(
-        help="ElasticSearch index definition (see https://www.elastic.co/"
-        "guide/en/elasticsearch/reference/current/"
-        "indices-create-index.html)",
-    )
 
     @api.constrains("config_id", "backend_id")
     def _check_config_id_required(self):

--- a/connector_search_engine/views/se_backend.xml
+++ b/connector_search_engine/views/se_backend.xml
@@ -28,6 +28,7 @@
                                 <field name="model_id" />
                                 <field name="exporter_id" />
                                 <field name="batch_size" />
+                                <field name="config_id" />
                                 <button
                                     name="force_recompute_all_binding"
                                     help="Force to recompute all binding of the index and set them to the state 'To update'"


### PR DESCRIPTION
There is no reasons to hide config_id  in connector_search_engine

And the help message in connector_elasticsearch overflow in other
implementations