### PR TITLE
[14.0] connector_search_engine : Fix index name bug

### DIFF
--- a/connector_search_engine/models/se_index.py
+++ b/connector_search_engine/models/se_index.py
@@ -101,7 +101,12 @@ class SeIndex(models.Model):
     )
     def _compute_name(self):
         for rec in self:
-            rec.name = rec._make_name()
+            if not rec.backend_id:
+                # in onchange on concrete views rec is a new Id
+                # so we can't calc the right name.
+                rec.name = ""
+            else:
+                rec.name = rec._make_name()
 
     def _make_name(self):
         """Compute the final name of the index."""

--- a/connector_search_engine/readme/CONTRIBUTORS.rst
+++ b/connector_search_engine/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Sébastien BEAU <sebastien.beau@akretion.com>
 * Laurent Mignon <laurent.mignon@acsone.eu>
 * Simone Orsi <simone.orsi@camptocamp.com>
+* Raphaël Reverdy <raphael.reverdy@akretion.com>


### PR DESCRIPTION
From concrete view (ie elasticsearch backend), on index creation
an onchange is triggered with a record.newId.

So self.backend_id will be False and trigger bugs in _make_name()