### PR TITLE
[14.0][IMP] `connector_elasticsearch`: Remove `es.ping()` from `_get_es_client`

### DIFF
--- a/connector_elasticsearch/components/adapter.py
+++ b/connector_elasticsearch/components/adapter.py
@@ -37,20 +37,16 @@ class ElasticsearchAdapter(Component):
 
     def _get_es_client(self):
         backend = self.backend_record
-
-        api_key = None
-        if backend.api_key_id and backend.api_key:
-            api_key = (backend.api_key_id, backend.api_key)
-        es = elasticsearch.Elasticsearch(
+        api_key = (
+            (backend.api_key_id, backend.api_key)
+            if backend.api_key_id and backend.api_key
+            else None
+        )
+        return elasticsearch.Elasticsearch(
             [backend.es_server_host],
             connection_class=self._es_connection_class,
             api_key=api_key,
         )
-
-        if not es.ping():  # pragma: no cover
-            raise ValueError("Connect Exception with elasticsearch")
-
-        return es
 
     def index(self, records):
         es = self._get_es_client()

--- a/connector_elasticsearch/views/se_backend_elasticsearch.xml
+++ b/connector_elasticsearch/views/se_backend_elasticsearch.xml
@@ -13,9 +13,24 @@
             </form>
             <field name="specific_backend" position="replace" />
             <group name="se-main" position="inside">
-                <field name="es_server_host" placeholder="http://elactic:9200" />
+                <field
+                    name="es_server_host"
+                    string="Host"
+                    placeholder="http://elastic:9200"
+                />
                 <field name="api_key_id" />
                 <field name="api_key" />
+            </group>
+            <group name="se-main" position="after">
+                <group name="se-buttons" colspan="4" col="1">
+                    <button
+                        name="action_test_connection"
+                        type="object"
+                        string="Test Connection"
+                        icon="fa-television"
+                        attrs="{'invisible': [('es_server_host', '=', False)]}"
+                    />
+                </group>
             </group>
         </field>
     </record>


### PR DESCRIPTION
**Reasoning:**

1) ``es.ping`` requires the user has Cluster Monitor permissions. It's a shame having to promote the user solely for this.

2) ``es.ping`` adds an extra HTTP request everytime ``_get_es_client`` is called. If anything bad happens, the real request will raise the exception anyways.


This PR also adds a Test connection button on the form view, to ease its configuration.