### PR TITLE
[14.0][FIX] connector_algolia: Cast incoming objectID to int

### DIFF
--- a/connector_search_engine/components/adapter.py
+++ b/connector_search_engine/components/adapter.py
@@ -31,4 +31,6 @@ class SeAdapter(AbstractComponent):
         raise NotImplementedError()
 
     def external_id(self, record):
-        return record[self._record_id_key]
+        # Doesn't matter how the external id is stored on SE side, it should always
+        # be a valid odoo id.
+        return int(record[self._record_id_key])


### PR DESCRIPTION
Algolia accepts both `int` and `string` as `objectID`, but will convert them
to a string anyway as mentionned [here](https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/in-depth/what-is-in-a-record/#unique-record-identifier).
When retrieving algolia records, we were trying to browse odoo records
from this objectID, which led to this kind of error:
```
Odoo Server Error
Traceback (most recent call last):
[...]
Exception
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
 File "/odoo/src/odoo/http.py", line 641, in _handle_exception
 return super(JsonRequest, self)._handle_exception(exception)
 File "/odoo/src/odoo/http.py", line 317, in _handle_exception
 raise exception.with_traceback(None) from new_cause
psycopg2.DataError: value "7960745000" is out of range for type integer
LINE 1: ...vader_variant" WHERE "shopinvader_variant".id IN ('796074500...
 ^
```

This PR ensures that this `objectID` is casted to an integer.