### PR TITLE
[ADD] se.index : store name

### DIFF
--- a/connector_search_engine/models/se_index.py
+++ b/connector_search_engine/models/se_index.py
@@ -13,7 +13,7 @@ class SeIndex(models.Model):
     _name = "se.index"
     _description = "Se Index"
 
-    name = fields.Char(compute="_compute_name")
+    name = fields.Char(compute="_compute_name", store=True)
     custom_tech_name = fields.Char(
         help="Take control of index technical name. "
         "The final index name is still computed and contains in any case: "


### PR DESCRIPTION
in order to filter for example variants based on index the name needs to be searchable
as you can see in the compute, the name is a complex field and a search method is not easy
as the compute already have the needed depends, i don't think it will be bad to store this field