### PR TITLE
[14.0][IMP] connector_elasticsearch: Connection test should work in all cases

### DIFF
--- a/connector_elasticsearch/models/se_backend_elasticsearch.py
+++ b/connector_elasticsearch/models/se_backend_elasticsearch.py
@@ -42,7 +42,7 @@ class SeBackendElasticsearch(models.Model):
             adapter = work.component(usage="se.backend.adapter")
             es = adapter._get_es_client()
             try:
-                es.security.authenticate()
+                es.info()
             except NotFoundError:
                 raise UserError(_("Unable to reach host."))
             except AuthenticationException:


### PR DESCRIPTION
As it will answer by default a 405 html code, we need to use
a simpler function.