### PR TITLE
[FIX] connector_search_engine: not possible to edit index lines

### DIFF
--- a/connector_search_engine/views/se_index.xml
+++ b/connector_search_engine/views/se_index.xml
@@ -49,11 +49,10 @@
         >se.index.tree with backend hidden (in connector_search_engine)</field>
         <field name="model">se.index</field>
         <field name="mode">primary</field>
+        <field name="priority" eval="200" />
         <field name="inherit_id" ref="connector_search_engine.se_index_tree_view" />
         <field name="arch" type="xml">
-            <field name="backend_id" position="attributes">
-                <attribute name="invisible">1</attribute>
-            </field>
+            <field name="backend_id" position="replace" />
         </field>
     </record>
     <record model="ir.ui.view" id="se_index_search_view">


### PR DESCRIPTION
Tree view (into backend) who displays indexes remove `backend_id` (invisible field) so not possible to edit a line (to update the `exporter_id` for example). Removing this no-visible field solve the issue.