### PR TITLE
[14.0][IMP] connector_search_engine: prioritize the json recomputation.

### DIFF
--- a/connector_search_engine/views/se_index.xml
+++ b/connector_search_engine/views/se_index.xml
@@ -8,6 +8,7 @@
         <field name="arch" type="xml">
             <tree string="Index" editable="bottom">
                 <field name="custom_tech_name" optional="hide" />
+                <field name="sequence" widget="handle" />
                 <field
                     name="backend_id"
                     invisible="context.get('from_backend_view', False)"


### PR DESCRIPTION
When we have a big database with a lot of products and categories binded, some recompute can overlap and cause some 'Concurrent update' on database, depending on the order of the index.

For example, `shopinvader.category` should always be recomputed before `shopinvader.variant`.
So let the possibility to the user to set the order (via `sequence` field) and use this order to create a dependency between jobs (`Delayable` objects).

Concretely, recompute jobs for `shopinvader.categories` should all be `done` to start recompute jobs for `shopinvader.variant`.


![image](https://user-images.githubusercontent.com/30529208/221161347-16828c28-c35a-4e2b-990b-d066e5e2ef81.png)
