### PR TITLE
[14.0] connector_algolia: prevent export record quota exceeded

### DIFF
--- a/connector_algolia/models/se_backend_algolia.py
+++ b/connector_algolia/models/se_backend_algolia.py
@@ -1,10 +1,16 @@
 # Copyright 2013 Akretion (http://www.akretion.com)
 # Raphaël Valyi <raphael.valyi@akretion.com>
 # Sébastien BEAU <sebastien.beau@akretion.com>
+# Copyright 2019 Camptocamp (http://www.camptocamp.com)
+# Simone Orsi <simone.orsi@camptocamp.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 
-from odoo import fields, models
+from odoo import _, fields, models
+
+from ..utils import get_dict_bytes_size
+
+RECORD_QUOTA = 10000  # bytes
 
 
 class SeBackendAlgolia(models.Model):
@@ -37,3 +43,12 @@ class SeBackendAlgolia(models.Model):
 
     def _get_api_credentials(self):
         return {"password": self.algolia_api_key}  # pragma: no cover
+
+    def _validate_record(self, index_record):
+        error = super()._validate_record(index_record)
+        if error:
+            return error
+        # validate size
+        size = get_dict_bytes_size(index_record)
+        if size > RECORD_QUOTA:
+            return _("Algolia record quota exceeded")

--- a/connector_algolia/models/se_binding.py
+++ b/connector_algolia/models/se_binding.py
@@ -2,10 +2,10 @@
 # Simone Orsi <simahawk@gmail.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-import json
-
 from odoo import api, fields, models
 from odoo.tools import human_size
+
+from ..utils import get_dict_bytes_size
 
 
 class SeBinding(models.AbstractModel):
@@ -23,7 +23,4 @@ class SeBinding(models.AbstractModel):
     @api.depends("data")
     def _compute_data_size(self):
         for rec in self:
-            rec.data_size = human_size(rec._get_bytes_size())
-
-    def _get_bytes_size(self):
-        return len(json.dumps(self.data or {}))
+            rec.data_size = human_size(get_dict_bytes_size(rec.data))

--- a/connector_algolia/tests/test_se_algolia.py
+++ b/connector_algolia/tests/test_se_algolia.py
@@ -142,11 +142,12 @@ class TestAlgoliaBackend(VCRMixin, TestBindingIndexBase):
     @mute_logger("odoo.addons.connector_search_engine.models.se_binding")
     def test_missing_object_key(self):
         self.record_id_export_line.unlink()
-        res = self.partner_binding.recompute_json()
-        error_string = "\n".join(
-            ["Validation errors", "{}: The key `objectID` is missing in:"]
-        ).format(str(self.partner_binding))
-        self.assertTrue(res.startswith(error_string))
+        result = self.partner_binding.recompute_json()
+        self.assertEqual(
+            result,
+            "Validation errors:\n\n  "
+            f"The key `objectID` is missing - IDs: {self.partner_binding.id}",
+        )
 
     def test_added_object_key(self):
         self.assertTrue(self.partner_binding.data)
@@ -189,7 +190,6 @@ class TestAlgoliaBackend(VCRMixin, TestBindingIndexBase):
         self.assertEqual(self.partner_binding.sync_state, "to_be_checked")
         self.assertEqual(
             result,
-            "Validation errors\n"
-            "res.partner.binding.fake(%s,): Algolia record quota exceeded"
-            % self.partner_binding.id,
+            "Validation errors:\n\n  "
+            f"Algolia record quota exceeded - IDs: {self.partner_binding.id}",
         )

--- a/connector_algolia/utils.py
+++ b/connector_algolia/utils.py
@@ -1,6 +1,7 @@
-# Copyright 2017-2018 Simone Orsi
+# Copyright 2017 Simone Orsi
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 # Borrowed from cms_form.utils
+import json
 
 
 def data_merge(a, b):
@@ -42,3 +43,7 @@ def data_merge(a, b):
             '"{}" in key "{}" when merging "{}" into "{}"'.format(e, key, b, a)
         )
     return a
+
+
+def get_dict_bytes_size(data):
+    return len(json.dumps(data or {}))

--- a/connector_search_engine/models/se_backend_spec_abstract.py
+++ b/connector_search_engine/models/se_backend_spec_abstract.py
@@ -69,4 +69,4 @@ class SeBackendSpecAbstract(models.AbstractModel):
             return _("The record is empty")
         if not record.get(self._record_id_key):
             # Ensure _record_id_key is set when creating/updating records
-            return _("The key `%s` is missing in:\n%s") % (self._record_id_key, record)
+            return _("The key `%(key)s` is missing") % {"key": self._record_id_key}

--- a/connector_search_engine/models/se_binding.py
+++ b/connector_search_engine/models/se_binding.py
@@ -195,7 +195,7 @@ class SeBinding(models.AbstractModel):
                 error = self._validate_record(work, index_record)
                 if error:
                     msg = "{}: {}".format(str(binding), error)
-                    _logger.error(msg)
+                    _logger.warning(msg)
                     validation_errors.append(msg)
                     to_be_checked.append(binding.id)
                     # skip record

--- a/connector_search_engine/tests/test_all.py
+++ b/connector_search_engine/tests/test_all.py
@@ -380,9 +380,8 @@ class TestBindingIndex(TestBindingIndexBaseFake):
         self.assertEqual(self.partner_binding.sync_state, "to_be_checked")
         self.assertEqual(
             result,
-            "Validation errors\n"
-            "res.partner.binding.fake(%s,): Something wrong with data"
-            % self.partner_binding.id,
+            "Validation errors:\n\n  "
+            f"Something wrong with data - IDs: {self.partner_binding.id}",
         )
 
     def test_recompute_json_to_be_checked_rollback(self):
@@ -412,7 +411,7 @@ class TestBindingIndex(TestBindingIndexBaseFake):
     def test_missing_record_key(self):
         self.record_id_export_line.unlink()
         res = self.partner_binding.recompute_json()
-        error_string = "\n".join(
-            ["Validation errors", "{}: The key `id` is missing in:"]
-        ).format(str(self.partner_binding))
-        self.assertTrue(res.startswith(error_string))
+        self.assertEqual(
+            res,
+            f"Validation errors:\n\n  The key `id` is missing - IDs: {self.partner_binding.id}",
+        )


### PR DESCRIPTION
It's pointless to try to export records w/ a size that exceeded the fixed quota. Such records should be skipped and flagged as to be checked.