### PR TITLE
[14.0] connector_search_engine: fix job form result overflow

### DIFF
--- a/connector_search_engine/models/se_binding.py
+++ b/connector_search_engine/models/se_binding.py
@@ -215,7 +215,7 @@ class SeBinding(models.AbstractModel):
     def _format_recompute_json_validation_errors(self, validation_errors):
         res = [_("Validation errors:")]
         for error, record_ids in validation_errors.items():
-            ids = ",".join([str(x) for x in record_ids])
+            ids = ", ".join([str(x) for x in record_ids])
             res.append(f"\n  {error} - IDs: {ids}")
             _logger.warning("%s: %s", error, ids)
         return "\n".join(res)


### PR DESCRIPTION
Simply let the browser format text properly thanks to spaces.

Followup of https://github.com/OCA/search-engine/pull/144

**Before:**

![se-validation-error-old](https://user-images.githubusercontent.com/347149/231770705-0ccfbb93-42fb-4e46-be27-a878391d60bc.png)


**After:**

![se-validation-error-new](https://user-images.githubusercontent.com/347149/231770736-e55f5276-7050-4f08-84a6-f3ab27809898.png)
