### PR TITLE
[16.0] connector_search_engine: contextualize

### DIFF
--- a/connector_search_engine/models/se_binding.py
+++ b/connector_search_engine/models/se_binding.py
@@ -130,6 +130,13 @@ class SeBinding(models.Model):
                 description=description, identity_key=identity_exact
             ).recompute_json(force_export=force_export)
 
+    def _contextualize(self, record):
+        ctx = {"index_id": record.index_id.id}
+        # force the lang if needed
+        if record.index_id.lang_id:
+            ctx["lang"] = record.index_id.lang_id.code
+        return record.with_context(**ctx)
+
     def recompute_json(self, force_export: bool = False):
         """ "Compute index record data as JSON."""
         # `sudo` because the recomputation can be triggered from everywhere
@@ -147,10 +154,9 @@ class SeBinding(models.Model):
                     "flag the binding to be deleted"
                 )
                 continue
+
+            record = self._contextualize(record)
             index = record.index_id
-            # force the lang if needed
-            if index.lang_id:
-                record = record.with_context(lang=index.lang_id.code)
 
             old_data = record.data
             try:


### PR DESCRIPTION
add the ability for other modules to inject variables into the context during the recompute