### PR TITLE
[16.0][FIX] connector_search_engine: add compatibility for python <3.10

### DIFF
--- a/connector_search_engine/models/se_index.py
+++ b/connector_search_engine/models/se_index.py
@@ -3,7 +3,7 @@
 
 import logging
 from collections import defaultdict
-from typing import List
+from typing import List, Union
 
 from odoo import _, api, fields, models
 
@@ -219,7 +219,7 @@ class SeIndex(models.Model):
         ).batch_recompute(force_export)
 
     @api.model
-    def generate_batch_sync_per_index(self, domain: list | None = None) -> None:
+    def generate_batch_sync_per_index(self, domain: Union[list, None] = None) -> None:
         """Generate a job for each index to sync.
 
         This method is usually called by a cron. It will generate a job for each
@@ -232,7 +232,9 @@ class SeIndex(models.Model):
             record._jobify_batch_sync()
 
     @api.model
-    def generate_batch_recompute_per_index(self, domain: list | None = None) -> None:
+    def generate_batch_recompute_per_index(
+        self, domain: Union[list, None] = None
+    ) -> None:
         """Generate a job for each index to recompute.
 
         This method is usually called by a cron. It will generate a job for each

--- a/connector_search_engine/models/se_indexable_record.py
+++ b/connector_search_engine/models/se_indexable_record.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from lxml import etree
 
@@ -167,7 +167,7 @@ class SeIndexableRecord(models.AbstractModel):
         bindings = self._get_bindings(indexes)
         bindings.write({"state": "to_delete"})
 
-    def _se_mark_to_update(self, indexes: SeIndex | None = None) -> None:
+    def _se_mark_to_update(self, indexes: Union[SeIndex, None] = None) -> None:
         """Mark the record to be updated in the index."""
         bindings = self._get_bindings(indexes)
         bindings.write({"state": "to_recompute"})


### PR DESCRIPTION
The union of types using the | syntax was introduced in Python 3.10, and it's not valid in Python 3.8. We get an error during installation of the module. @lmignon I am not sure if I fixed entirely.

