### PR TITLE
[16.0][FIX] search_engine_image_thumbnail: Avoid error on view load

### DIFF
--- a/search_engine_image_thumbnail/models/se_image_field_thumbnail_size.py
+++ b/search_engine_image_thumbnail/models/se_image_field_thumbnail_size.py
@@ -114,6 +114,8 @@ class SeImageFieldThumbnailSize(models.Model):
             return True
         if not field.comodel_name:
             return False
+        if field.comodel_name not in self.env:
+            return False
         abstract = self.env["fs.image.relation.mixin"]
         model = self.env[field.comodel_name]
         return isinstance(model, abstract.__class__)


### PR DESCRIPTION
In the thumbnail size form a domain is computed to restrict the model's field for which the size is defined. The build process filters of type FSImage of relational field to image relation model. In this mechanism we check the comodel_name info to validate the related model if a comodel_name is defined on a field. In some cases (related), the comodel_name doesn't refer to an odoo model. (A bug?). We now ignore fields with a comodel_name not part of the registry