### PR TITLE
[FIX] [FIX] connector_search_engine: avoid catching pg error in binding recompute json

### DIFF
--- a/connector_search_engine/models/se_binding.py
+++ b/connector_search_engine/models/se_binding.py
@@ -7,6 +7,7 @@ import logging
 from collections import defaultdict
 from typing import Any, Dict, Iterator
 
+from psycopg2.errors import Error
 from typing_extensions import Self
 
 from odoo import _, api, fields, models, tools
@@ -166,6 +167,9 @@ class SeBinding(models.Model):
                 with self.env.cr.savepoint():
                     record.data = index.model_serializer.serialize(record.record)
                     record.date_recomputed = fields.Datetime.now()
+            except Error as pg_error:
+                # PG error could make the cursor unusable
+                raise pg_error
             except Exception as e:
                 record.state = "recompute_error"
                 record.error = str(e)


### PR DESCRIPTION
If a psycopg error occurs, the queue does not automatically retry the job. This is because we attempt to write the error to the binding after the SQL transaction ends, resulting in a job failure.
Since UserError exceptions is the base of all Odoo exceptions, catching it should be sufficient.