### PR TITLE
[16.0] search_engine_image_thumbnail: fix domain compute

### DIFF
--- a/search_engine_image_thumbnail/models/se_image_field_thumbnail_size.py
+++ b/search_engine_image_thumbnail/models/se_image_field_thumbnail_size.py
@@ -97,6 +97,10 @@ class SeImageFieldThumbnailSize(models.Model):
     @api.depends("model_id")
     def _compute_field_id_domain(self):
         for record in self:
+            if not record.model_id:
+                # Eg: NewId
+                record.field_id_domain = FALSE_DOMAIN
+                continue
             model = self.env[record.model_id.model]
             names = []
             for field in model._fields.values():


### PR DESCRIPTION
When creating a new backend you get NewId records which have an empty model and of course you get a KeyError when trying to load the model from the env.