### PR TITLE
[16.0][FIX] search_engine_image_thumbnail: field type binary

### DIFF
--- a/search_engine_image_thumbnail/models/se_image_field_thumbnail_size.py
+++ b/search_engine_image_thumbnail/models/se_image_field_thumbnail_size.py
@@ -5,8 +5,6 @@ import json
 from odoo import api, fields, models, tools
 from odoo.osv.expression import FALSE_DOMAIN
 
-from odoo.addons.base_sparse_field.models.fields import Serialized
-
 
 class SeImageFieldThumbnailSize(models.Model):
 
@@ -46,7 +44,7 @@ class SeImageFieldThumbnailSize(models.Model):
         readonly=True,
         store=True,
     )
-    field_id_domain = Serialized(
+    field_id_domain = fields.Binary(
         string="Domain to select images field",
         compute="_compute_field_id_domain",
         readonly=True,

--- a/search_engine_image_thumbnail/tests/test_se_multi_image_thumbnail.py
+++ b/search_engine_image_thumbnail/tests/test_se_multi_image_thumbnail.py
@@ -24,7 +24,7 @@ class TestSeMultiImageThumbnail(TestSeMultiImageThumbnailCase):
         field_id_domain = se_thumbnail_size.field_id_domain
         self.assertEqual(
             field_id_domain,
-            [["name", "in", ["image_ids"]], ["model_id", "=", model_id]],
+            f'[["name", "in", ["image_ids"]], ["model_id", "=", {model_id}]]'.encode(),
         )
 
     def test_multi_image_record_create_thumbnail(self):


### PR DESCRIPTION
see https://github.com/OCA/search-engine/issues/183

* [x]  includes [[16.0] search_engine_image_thumbnail: New config param #176](https://github.com/OCA/search-engine/pull/176)