### PR TITLE
[FIX] connector_search_engine: Remove from index on archive

### DIFF
--- a/connector_search_engine/models/se_indexable_record.py
+++ b/connector_search_engine/models/se_indexable_record.py
@@ -182,7 +182,7 @@ class SeIndexableRecord(models.AbstractModel):
     def write(self, vals):
         res = super().write(vals)
         if "active" in vals:
-            bindings = self._get_bindings()
+            bindings = self.sudo()._get_bindings()
             # if the record is archived then unarchived while the binding
             # are not already deleted we reset the state to_recompute
             new_state = "to_recompute" if vals["active"] else "to_delete"

--- a/connector_search_engine/models/se_indexable_record.py
+++ b/connector_search_engine/models/se_indexable_record.py
@@ -179,6 +179,21 @@ class SeIndexableRecord(models.AbstractModel):
         )
         return super().unlink()
 
+    def write(self, vals):
+        res = super().write(vals)
+        if "active" in vals:
+            bindings = self._get_bindings()
+            # if the record is archived then unarchived while the binding
+            # are not already deleted we reset the state to_recompute
+            new_state = "to_recompute" if vals["active"] else "to_delete"
+            bindings.write(
+                {
+                    "state": new_state,
+                }
+            )
+
+        return res
+
     @api.model
     def _get_view(self, view_id=None, view_type="form", **options):
         arch, view = super()._get_view(view_id=view_id, view_type=view_type, **options)

--- a/connector_search_engine/tests/test_all.py
+++ b/connector_search_engine/tests/test_all.py
@@ -170,6 +170,17 @@ class TestBindingIndex(TestBindingIndexBaseFake):
         self.partner.unlink()
         self.assertEqual(self.partner_binding.state, "to_delete")
 
+    def test_archive_record(self):
+        self.partner.active = False
+        self.assertEqual(self.partner_binding.state, "to_delete")
+
+    def test_archive_unarchive_record(self):
+        self.partner.active = False
+        self.assertEqual(self.partner_binding.state, "to_delete")
+        # IT the binding is not yet deleted it's nice to keep it on unarchive
+        self.partner.active = True
+        self.assertEqual(self.partner_binding.state, "to_recompute")
+
     def test_recompute_one_record(self):
         self.partner_binding.recompute_json()
         self.assertEqual(self.partner_binding.state, "to_export")


### PR DESCRIPTION
When a record is archived, marks the binding to be deleted