### PR TITLE
[14.0] connector_search_engine: keep data for bindins to check

### DIFF
--- a/connector_search_engine/models/se_binding.py
+++ b/connector_search_engine/models/se_binding.py
@@ -203,6 +203,7 @@ class SeBinding(models.AbstractModel):
                         vals["date_modified"] = fields.Datetime.now()
                     if error:
                         vals["sync_state"] = "to_be_checked"
+                        vals["data"]["__error__"] = error
                     binding.write(vals)
         if validation_errors:
             result.append(

--- a/connector_search_engine/models/se_binding.py
+++ b/connector_search_engine/models/se_binding.py
@@ -186,7 +186,6 @@ class SeBinding(models.AbstractModel):
         # be the same no matter the access rights of the user triggering this.
         result = []
         validation_errors = {}
-        to_be_checked = []
         for work in self.sudo()._work_by_index():
             mapper = work.component(usage="se.export.mapper")
             for binding in work.records.with_context(
@@ -197,21 +196,18 @@ class SeBinding(models.AbstractModel):
                 error = self._validate_record(work, index_record)
                 if error:
                     validation_errors.setdefault(error, []).append(binding.id)
-                    to_be_checked.append(binding.id)
-                    # skip record
-                    continue
-                if binding.data != index_record or force_export:
+                if binding.data != index_record or force_export or error:
                     vals = {"data": index_record}
                     if binding.sync_state != "to_update":
                         vals["sync_state"] = "to_update"
                         vals["date_modified"] = fields.Datetime.now()
+                    if error:
+                        vals["sync_state"] = "to_be_checked"
                     binding.write(vals)
         if validation_errors:
             result.append(
                 self._format_recompute_json_validation_errors(validation_errors)
             )
-        if to_be_checked:
-            self.browse(to_be_checked).write({"sync_state": "to_be_checked"})
         return "\n\n".join(result)
 
     def _format_recompute_json_validation_errors(self, validation_errors):

--- a/connector_search_engine/tests/test_all.py
+++ b/connector_search_engine/tests/test_all.py
@@ -383,6 +383,9 @@ class TestBindingIndex(TestBindingIndexBaseFake):
             "Validation errors:\n\n  "
             f"Something wrong with data - IDs: {self.partner_binding.id}",
         )
+        self.assertEqual(
+            self.partner_binding.data["__error__"], "Something wrong with data"
+        )
 
     def test_recompute_json_to_be_checked_rollback(self):
         # If something was to check but it's now good,


### PR DESCRIPTION
To help checking what the problem might be
do not skip storing the computed data.