### PR TITLE
[16.0][FIX] connector_search_engine: missing typing-extensions external dependency

### DIFF
--- a/connector_search_engine/__manifest__.py
+++ b/connector_search_engine/__manifest__.py
@@ -13,7 +13,7 @@
     "license": "AGPL-3",
     "category": "Generic Modules",
     "depends": ["queue_job", "mail", "server_environment", "base_partition"],
-    "external_dependencies": {"python": ["unidecode"]},
+    "external_dependencies": {"python": ["unidecode", "typing-extensions"]},
     "data": [
         "wizards/se_binding_state_updater.xml",
         "security/connector_search_engine_security.xml",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@
 elasticsearch>=7.0.0,<=7.13.4
 pydantic
 requests
+typing-extensions
 unidecode


### PR DESCRIPTION
Trivial PR to fix this kind of bug in CI:
https://github.com/OCA/sale-channel/actions/runs/8332403108/job/22801435634?pr=17#step:7:446

This bug doesn't occur on search-engine repo because the module [`search_engine_serializer_pydantic`](https://github.com/OCA/search-engine/blob/16.0/search_engine_serializer_pydantic/__manifest__.py#L15) use [`pydantic`](https://github.com/OCA/rest-framework/blob/16.0/pydantic/__manifest__.py#L18) which depends on python package `typing-extensions`. So typing-extensions is loaded anyway.

But when a module on another repo like [`sale_channel`](https://github.com/OCA/sale-channel) needs to use `connector_search_engine`without using `search_engine_serializer_pydantic`, the bug occurs.

Once this PR is merged I will be able to merge https://github.com/OCA/sale-channel/pull/17

cc @florian-dacosta @bealdav @rousseldenis @adrienpeiffer




