### PR TITLE
[16.0] connector_search_engine: add binding hooks to recompute and validate + include update TS

### DIFF
--- a/connector_search_engine/models/se_binding.py
+++ b/connector_search_engine/models/se_binding.py
@@ -195,7 +195,9 @@ class SeBinding(models.Model):
 
     def _recompute_data(self):
         self.date_recomputed = fields.Datetime.now()
-        self.data = self.index_id.model_serializer.serialize(self.record)
+        data = self.index_id.model_serializer.serialize(self.record)
+        data["updated_on"] = fields.Datetime.to_string(self.date_recomputed)
+        self.data = data
 
     def _validate_data(self):
         self.index_id.json_validator.validate(self.data or {})

--- a/connector_search_engine/tests/test_all.py
+++ b/connector_search_engine/tests/test_all.py
@@ -184,12 +184,16 @@ class TestBindingIndex(TestBindingIndexBaseFake):
     def test_recompute_one_record(self):
         self.partner_binding.recompute_json()
         self.assertEqual(self.partner_binding.state, "to_export")
-        self.assertEqual(self.partner_binding.get_export_data(), self.partner_expected)
+        data = self.partner_binding.get_export_data()
+        data.pop("updated_on")
+        self.assertEqual(data, self.partner_expected)
         self.assertTrue(self.partner_binding.date_recomputed)
 
     def test_recompute_all_indexes(self):
         self.env["se.index"].recompute_all_index()
-        self.assertEqual(self.partner_binding.get_export_data(), self.partner_expected)
+        data = self.partner_binding.get_export_data()
+        data.pop("updated_on")
+        self.assertEqual(data, self.partner_expected)
         self.assertEqual(self.partner_binding.state, "to_export")
         self.assertTrue(self.partner_binding.date_recomputed)
 

--- a/connector_search_engine_serializer_ir_export/tests/test_serializer.py
+++ b/connector_search_engine_serializer_ir_export/tests/test_serializer.py
@@ -33,8 +33,10 @@ class TestSerializer(TestBindingIndexBaseFake):
 
     def test_serialize(self):
         self.partner_binding.recompute_json()
+        data = self.partner_binding.data
+        data.pop("updated_on")
         self.assertEqual(
-            self.partner_binding.data,
+            data,
             {
                 "active": True,
                 "child_ids": [


### PR DESCRIPTION
As for the TS change (last commit) I think is very handy. However, we could include it only on demand (eg: flag on the index record).

Any feedback?