### PR TITLE
[FIX] search_engine_image_thumbnail: fix the domain type for image fields filter

### DIFF
--- a/search_engine_image_thumbnail/i18n/it.po
+++ b/search_engine_image_thumbnail/i18n/it.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2024-04-15 10:37+0000\n"
+"PO-Revision-Date: 2024-10-07 18:22+0000\n"
 "Last-Translator: mymage <stefano.consolaro@mymage.it>\n"
 "Language-Team: none\n"
 "Language: it\n"
@@ -60,11 +60,6 @@ msgid "Display Name"
 msgstr "Nome visualizzato"
 
 #. module: search_engine_image_thumbnail
-#: model:ir.model.fields,field_description:search_engine_image_thumbnail.field_se_image_field_thumbnail_size__field_id_domain
-msgid "Domain to select images field"
-msgstr "Dminio per selezionare il campo immagine"
-
-#. module: search_engine_image_thumbnail
 #: model:ir.model.fields,field_description:search_engine_image_thumbnail.field_se_backend__fails_if_no_thumbail_size
 msgid "Fail if no thumbnail size"
 msgstr "Fallisce se non c'è la misura miniatura"
@@ -104,6 +99,11 @@ msgstr "Campo immagine"
 #: model:ir.model.fields,field_description:search_engine_image_thumbnail.field_se_image_field_thumbnail_size__field_name
 msgid "Images field name"
 msgstr "Nome campo immagine"
+
+#. module: search_engine_image_thumbnail
+#: model:ir.model.fields,field_description:search_engine_image_thumbnail.field_se_image_field_thumbnail_size__allowed_field_ids
+msgid "Images fields"
+msgstr ""
 
 #. module: search_engine_image_thumbnail
 #: model:ir.model,name:search_engine_image_thumbnail.model_se_image_field_thumbnail_size

--- a/search_engine_image_thumbnail/i18n/search_engine_image_thumbnail.pot
+++ b/search_engine_image_thumbnail/i18n/search_engine_image_thumbnail.pot
@@ -57,11 +57,6 @@ msgid "Display Name"
 msgstr ""
 
 #. module: search_engine_image_thumbnail
-#: model:ir.model.fields,field_description:search_engine_image_thumbnail.field_se_image_field_thumbnail_size__field_id_domain
-msgid "Domain to select images field"
-msgstr ""
-
-#. module: search_engine_image_thumbnail
 #: model:ir.model.fields,field_description:search_engine_image_thumbnail.field_se_backend__fails_if_no_thumbail_size
 msgid "Fail if no thumbnail size"
 msgstr ""
@@ -98,6 +93,11 @@ msgstr ""
 #. module: search_engine_image_thumbnail
 #: model:ir.model.fields,field_description:search_engine_image_thumbnail.field_se_image_field_thumbnail_size__field_name
 msgid "Images field name"
+msgstr ""
+
+#. module: search_engine_image_thumbnail
+#: model:ir.model.fields,field_description:search_engine_image_thumbnail.field_se_image_field_thumbnail_size__allowed_field_ids
+msgid "Images fields"
 msgstr ""
 
 #. module: search_engine_image_thumbnail

--- a/search_engine_image_thumbnail/tests/test_se_multi_image_thumbnail.py
+++ b/search_engine_image_thumbnail/tests/test_se_multi_image_thumbnail.py
@@ -16,17 +16,6 @@ class TestSeMultiImageThumbnail(TestSeMultiImageThumbnailCase):
         domain = self.env["se.image.field.thumbnail.size"]._model_id_domain()
         self.assertEqual(domain, expected)
 
-    def test_thumbnail_zise_field_domain(self):
-        model_id = self.test_multi_image_model_id
-        se_thumbnail_size = self.env["se.image.field.thumbnail.size"].new(
-            {"model_id": model_id}
-        )
-        field_id_domain = se_thumbnail_size.field_id_domain
-        self.assertEqual(
-            field_id_domain,
-            f'[["name", "in", ["image_ids"]], ["model_id", "=", {model_id}]]'.encode(),
-        )
-
     def test_multi_image_record_create_thumbnail(self):
         thumbnails = self.test_multi_image._get_or_create_thumbnails_for_multi_images(
             self.index_multi_image, "image_ids"

--- a/search_engine_image_thumbnail/views/se_image_field_thumbnail_size.xml
+++ b/search_engine_image_thumbnail/views/se_image_field_thumbnail_size.xml
@@ -35,8 +35,8 @@
             <tree editable="top">
                 <field name="backend_id" invisible="context.get('hide_backend', 0)" />
                 <field name="model_id" />
-                <field name="field_id" domain="field_id_domain" />
-                <field name="field_id_domain" invisible="1" />
+                <field name="field_id" domain="[('id', 'in', allowed_field_ids), ('model_id', '=', model_id)]"/>
+                <field name="allowed_field_ids" widget="many2many_tags" invisible="1" />
                 <field name="size_ids" widget="many2many_tags" />
             </tree>
         </field>


### PR DESCRIPTION
The domain attribute is provided in the backend in the field definition.

Providing the domain in the form view caused a critical frontend error prohibiting me from choosing the value.