### PR TITLE
[FIX] search_engine_image_thumbnail: fix the domain type for image fields filter

### DIFF
--- a/search_engine_image_thumbnail/README.rst
+++ b/search_engine_image_thumbnail/README.rst
@@ -246,6 +246,8 @@ Contributors
 ------------
 
 -  Laurent Mignon laurent.mignon@acsone.eu (https://www.acsone.eu/)
+-  Mohamed Alkobrosli alkobroslymohamed@gmail.com
+   (https://www.kobros-tech.com/)
 
 Other credits
 -------------

--- a/search_engine_image_thumbnail/models/se_image_field_thumbnail_size.py
+++ b/search_engine_image_thumbnail/models/se_image_field_thumbnail_size.py
@@ -1,6 +1,5 @@
 # Copyright 2023 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-import json
 
 from odoo import api, fields, models, tools
 from odoo.osv.expression import FALSE_DOMAIN
@@ -107,7 +106,7 @@ class SeImageFieldThumbnailSize(models.Model):
             for field in domain_fields:
                 if self._is_field_valid_for_thumbnail(field):
                     names.append(field.name)
-            record.field_id_domain = json.dumps(
+            record.field_id_domain = (
                 [("name", "in", names), ("model_id", "=", record.model_id.id)]
                 if names
                 else FALSE_DOMAIN

--- a/search_engine_image_thumbnail/readme/CONTRIBUTORS.md
+++ b/search_engine_image_thumbnail/readme/CONTRIBUTORS.md
@@ -1,1 +1,2 @@
 - Laurent Mignon <laurent.mignon@acsone.eu> (https://www.acsone.eu/)
+- Mohamed Alkobrosli <alkobroslymohamed@gmail.com> (https://www.kobros-tech.com/)

--- a/search_engine_image_thumbnail/static/description/index.html
+++ b/search_engine_image_thumbnail/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -597,6 +598,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#toc-entry-12">Contributors</a></h2>
 <ul class="simple">
 <li>Laurent Mignon <a class="reference external" href="mailto:laurent.mignon&#64;acsone.eu">laurent.mignon&#64;acsone.eu</a> (<a class="reference external" href="https://www.acsone.eu/">https://www.acsone.eu/</a>)</li>
+<li>Mohamed Alkobrosli <a class="reference external" href="mailto:alkobroslymohamed&#64;gmail.com">alkobroslymohamed&#64;gmail.com</a>
+(<a class="reference external" href="https://www.kobros-tech.com/">https://www.kobros-tech.com/</a>)</li>
 </ul>
 </div>
 <div class="section" id="other-credits">
@@ -607,7 +610,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-14">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/search_engine_image_thumbnail/tests/test_se_multi_image_thumbnail.py
+++ b/search_engine_image_thumbnail/tests/test_se_multi_image_thumbnail.py
@@ -23,8 +23,8 @@ class TestSeMultiImageThumbnail(TestSeMultiImageThumbnailCase):
         )
         field_id_domain = se_thumbnail_size.field_id_domain
         self.assertEqual(
-            field_id_domain,
-            f'[["name", "in", ["image_ids"]], ["model_id", "=", {model_id}]]'.encode(),
+            f"{field_id_domain}",
+            f"[('name', 'in', ['image_ids']), ('model_id', '=', {model_id})]",
         )
 
     def test_multi_image_record_create_thumbnail(self):


### PR DESCRIPTION
The datatype of the domain in the computed method was not correct.
It is reviewed with ACSONE.

It is an extension of a closed pull request:
[https://github.com/OCA/search-engine/pull/198](https://github.com/OCA/search-engine/pull/198)

@lmignon 