### PR TITLE
[16.0][FIX] connector_search_engine: loop on recordset to call export_settings as it uses an ensure_one

### DIFF
--- a/connector_search_engine/models/se_index.py
+++ b/connector_search_engine/models/se_index.py
@@ -344,7 +344,8 @@ class SeIndex(models.Model):
 
     @api.model
     def export_all_settings(self) -> None:
-        self.search([]).export_settings()
+        for rec in self.search([]):
+            rec.export_settings()
 
     def export_settings(self) -> None:
         self.ensure_one()


### PR DESCRIPTION
Loop on recordset to call export_settings as it uses an ensure_one to prevent the cron to fail when there is more than one index