### PR TITLE
[16.0] connector_search_engine: _add_to_index and _remove_to_index required indexes

### DIFF
--- a/connector_search_engine/models/se_indexable_record.py
+++ b/connector_search_engine/models/se_indexable_record.py
@@ -136,6 +136,8 @@ class SeIndexableRecord(models.AbstractModel):
         :param index: The index where the record should be added
         :return: The binding recordset
         """
+        if not indexes:
+            raise ValueError("Indexes are mandatory")
         bindings = self._get_bindings(indexes)
         bindings.filtered(lambda s: s.state == "to_delete").write(
             {"state": "to_recompute"}
@@ -162,6 +164,8 @@ class SeIndexableRecord(models.AbstractModel):
         Once the data will be removed from the index, the binding will be
         deleted.
         """
+        if not indexes:
+            raise ValueError("Indexes are mandatory")
         bindings = self._get_bindings(indexes)
         bindings.write({"state": "to_delete"})
 

--- a/connector_search_engine/tests/test_all.py
+++ b/connector_search_engine/tests/test_all.py
@@ -166,6 +166,10 @@ class TestBindingIndex(TestBindingIndexBaseFake):
         self.partner._remove_from_index(self.se_index)
         self.assertEqual(self.partner_binding.state, "to_delete")
 
+    def test_remove_from_index_no_values(self):
+        with self.assertRaisesRegex(ValueError, "Indexes are mandatory"):
+            self.partner._remove_from_index(self.env["se.index"])
+
     def test_unlink_record(self):
         self.partner.unlink()
         self.assertEqual(self.partner_binding.state, "to_delete")
@@ -402,3 +406,7 @@ class TestBindingIndex(TestBindingIndexBaseFake):
             ValidationError, "Binding model must be equal to the index model"
         ):
             user._add_to_index(self.se_index)
+
+    def test_add_to_index_no_values(self):
+        with self.assertRaisesRegex(ValueError, "Indexes are mandatory"):
+            self.partner._add_to_index(self.env["se.index"])


### PR DESCRIPTION
In case that we call this method with an empty index it generate unexpected behaviour see PR: https://github.com/OCA/sale-channel/pull/23 As it do not make any sense to call this method with an empty records make it mandatory to avoid futur bug