### PR TITLE
[16.0][IMP] connector_search_engine: Eases the access from binding to record

### DIFF
--- a/connector_search_engine/models/se_binding.py
+++ b/connector_search_engine/models/se_binding.py
@@ -76,6 +76,11 @@ class SeBinding(models.Model):
     res_model = fields.Selection(
         selection=lambda s: s._get_indexable_model_selection(), readonly=True
     )
+    record_id = fields.Reference(
+        selection=lambda s: s._get_indexable_model_selection(),
+        compute="_compute_record_id",
+        readonly=True,
+    )
 
     _sql_constraints = [
         (
@@ -114,6 +119,17 @@ class SeBinding(models.Model):
         if len(set(self.mapped("res_model"))) > 1:
             raise ValueError("All record must have the same model")
         return self.env[self[0].res_model].browse(self.mapped("res_id")).exists()
+
+    @api.depends("res_model", "res_id")
+    def _compute_record_id(self):
+        """Compute the record field."""
+        for binding in self:
+            if binding.res_model and binding.res_id:
+                binding.record_id = (
+                    self.env[binding.res_model].browse(binding.res_id).exists()
+                )
+            else:
+                binding.record_id = False
 
     @api.depends("data")
     def _compute_data_display(self):

--- a/connector_search_engine/views/se_binding_view.xml
+++ b/connector_search_engine/views/se_binding_view.xml
@@ -15,6 +15,7 @@
                 <field name="date_synchronized" />
                 <field name="res_model" invisible="context.get('hide_res_model')" />
                 <field name="res_id" invisible="context.get('hide_res_model')" />
+                <field name="record_id" invisible="context.get('hide_res_model')" />
             </tree>
         </field>
     </record>
@@ -31,6 +32,7 @@
                     <field name="date_synchronized" />
                     <field name="res_model" />
                     <field name="res_id" />
+                    <field name="record_id" />
                 </group>
                 <group string="Error" attrs="{'invisible': [('error', '=', False)]}">
                     <field name="error" nolabel="1" colspan="4" />


### PR DESCRIPTION
A new field has been added to facilitate navigation from a binding to the record. This field will enable simple diagnosis of json recomputation problems, for example.