### PR TITLE
[16.0][IMP] connector_search_engine: Eases debug in case of recompute error

### DIFF
--- a/connector_search_engine/models/se_binding.py
+++ b/connector_search_engine/models/se_binding.py
@@ -4,6 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import json
 import logging
+import traceback
 from collections import defaultdict
 from typing import Any, Dict, Iterator
 
@@ -198,7 +199,15 @@ class SeBinding(models.Model):
                 raise pg_error
             except Exception as e:
                 record.state = "recompute_error"
-                record.error = str(e)
+                stack = traceback.format_exc()
+                error = f"{e} \n\n {stack}"
+                record.error = error
+                _logger.exception(
+                    "Error while recomputing the json for %s %s: %s",
+                    record.res_model,
+                    record.res_id,
+                    record.record_id.display_name,
+                )
                 continue
             try:
                 index.json_validator.validate(record.data or {})


### PR DESCRIPTION
Add the stacktrace into the error description to ease the debug of exception orruring into the json's recompute process.