### PR TITLE
[IMP] connector_elasticsearch: timeout and retries

### DIFF
--- a/connector_elasticsearch/models/se_backend.py
+++ b/connector_elasticsearch/models/se_backend.py
@@ -37,6 +37,22 @@ class SeBackend(models.Model):
         default=True,
         help="Verify SSL certificates. Only set to False in development environments.",
     )
+    es_timeout = fields.Integer(
+        string="Elasticsearch timeout",
+        default=10,
+        help="Elastic Search request timeout",
+    )
+    es_max_retries = fields.Integer(
+        string="Elasticsearch max retries",
+        default=0,
+        help="Number of retries, when an occurs. "
+        "0 or negative means no retries and the exception is raised.",
+    )
+    es_retry_on_timeout = fields.Boolean(
+        string="Elasticsearch retry on timeout",
+        help="If set, retry when a connection timeout occurs. "
+        "Otherwise, the retries are only on other errors",
+    )
 
     @property
     def _server_env_fields(self):

--- a/connector_elasticsearch/tools/adapter.py
+++ b/connector_elasticsearch/tools/adapter.py
@@ -61,6 +61,9 @@ class ElasticSearchAdapter(SearchEngineAdapter):
                 [backend.es_server_host],
                 connection_class=self._es_connection_class,
                 api_key=api_key,
+                timeout=max(backend.es_timeout, 1),
+                retry_on_timeout=backend.es_retry_on_timeout,
+                max_retries=max(0, backend.es_max_retries),
             )
         if backend.auth_type == "http":
             auth = (backend.es_user, backend.es_password)

--- a/connector_elasticsearch/views/se_backend.xml
+++ b/connector_elasticsearch/views/se_backend.xml
@@ -43,6 +43,11 @@
                         attrs="{'invisible': [('auth_type', '!=', 'api_key')]}"
                     />
                 </group>
+                <group name="se-params">
+                    <field string="Max retries" name="es_max_retries" />
+                    <field string="Retry on timeout" name="es_retry_on_timeout" />
+                    <field string="Timeout" name="es_timeout" />
+                </group>
             </group>
         </field>
     </record>


### PR DESCRIPTION
Add configuration options on the elasticsearch backend model to support passing the timeout / max_retries / retry_on_timeout argument to the Elasticsearch constructor.