### PR TITLE
[16.0] fix se mark to update

### DIFF
--- a/connector_search_engine/models/se_indexable_record.py
+++ b/connector_search_engine/models/se_indexable_record.py
@@ -172,7 +172,9 @@ class SeIndexableRecord(models.AbstractModel):
     def _se_mark_to_update(self, indexes: SeIndex | None = None) -> None:
         """Mark the record to be updated in the index."""
         bindings = self._get_bindings(indexes)
-        bindings.write({"state": "to_recompute"})
+        bindings.filtered(lambda s: s.state != "to_delete").write(
+            {"state": "to_recompute"}
+        )
 
     def unlink(self):
         bindings = self.sudo()._get_bindings()

--- a/connector_search_engine/tests/test_all.py
+++ b/connector_search_engine/tests/test_all.py
@@ -370,3 +370,22 @@ class TestBindingIndex(TestBindingIndexBaseFake):
             self.assertEqual(len(calls), 2)
             self.assertEqual(calls[1]["method"], "delete")
             self.assertEqual(calls[1]["args"], [none_existing_partner_id, "wtf"])
+
+    def test_se_mark_to_update(self):
+        self.partners = self.env["res.partner"].create(
+            [
+                {"name": "Foo"},
+                {"name": "Bar"},
+            ]
+        )
+        self.partners._add_to_index(self.se_index)
+
+        # Now for some reason the first partner is removed from the index
+        self.partners[0]._remove_from_index(self.se_index)
+
+        # And something (like a write) trigger an "_se_mark_to_update"
+        self.partners._se_mark_to_update()
+
+        # We ensure that the binding is still in "to_delete"
+        self.assertEqual(self.partners[0].se_binding_ids.state, "to_delete")
+        self.assertEqual(self.partners[1].se_binding_ids.state, "to_recompute")


### PR DESCRIPTION
Fix issue : https://github.com/OCA/sale-channel/pull/15

Mark update should not change the state of binding that are planned to be deleted

Check the last commit : @qgroulard


Depends on (include commit): 
- [x] https://github.com/OCA/search-engine/pull/211