### PR TITLE
[18.0][FIX] se_index: update constrain to unique 'name' instead of lang+model

### DIFF
--- a/connector_search_engine/models/se_index.py
+++ b/connector_search_engine/models/se_index.py
@@ -113,9 +113,9 @@ class SeIndex(models.Model):
 
     _sql_constraints = [
         (
-            "lang_model_uniq",
-            "unique(backend_id, lang_id, model_id)",
-            "Lang and model of index must be uniq per backend.",
+            "name_uniq",
+            "unique(backend_id, name)",
+            "The index name must be unique per backend.",
         )
     ]
 


### PR DESCRIPTION
Before, the previous constrain was preventing 2 indexes on the same Odoo model
This change allow this behavior, by keeping the security of not having 2 indexes with same name in Odoo (which is the point to verify for consistency with the Search Engine).

Exemple: from `res.partner`, I want to push to a Search Engine 2 indexes: one "companies", another one "persons".
=> This PR allows it.