### PR TITLE
[18.0] connector_search_engine: fix migration ui and improve UI

### DIFF
--- a/connector_search_engine/models/se_binding.py
+++ b/connector_search_engine/models/se_binding.py
@@ -154,6 +154,7 @@ class SeBinding(models.Model):
             # Nothing to do
             return
         size = min(self.index_id.mapped("batch_exporting_size"))
+        self.write({"state": "recomputing"})
         for binding in self.with_context(tracking_disable=True)._batch(size):
             description = self.env._(
                 "Recompute %(name)s json and check if need update", name=self._name
@@ -245,7 +246,6 @@ class SeBinding(models.Model):
                 ("res_id", "in", self._context["active_ids"]),
             ]
         )
-        bindings.write({"state": "recomputing"})
         bindings.jobify_recompute_json()
 
     @api.model_create_multi

--- a/connector_search_engine/models/se_index.py
+++ b/connector_search_engine/models/se_index.py
@@ -69,17 +69,17 @@ class SeIndex(models.Model):
             aggregates=["__count"],
         )
         _all = 0
-        for index_id, state, count in data:
-            res[index_id][state] = count
+        for index, state, count in data:
+            res[index][state] = count
             _all += count
 
-        def get(index_id, states):
-            return sum([res[index_id][state] for state in states])
+        def get(index, states):
+            return sum([res[index][state] for state in states])
 
         for record in self:
-            record.count_done = get(record.id, ["done"])
+            record.count_done = get(record, ["done"])
             record.count_pending = get(
-                record.id,
+                record,
                 [
                     "to_recompute",
                     "recomputing",
@@ -89,7 +89,7 @@ class SeIndex(models.Model):
                     "deleting",
                 ],
             )
-            record.count_error = get(record.id, ["invalid_data", "recompute_error"])
+            record.count_error = get(record, ["invalid_data", "recompute_error"])
             record.count_all = _all
             if record.count_error:
                 record.color = 1

--- a/connector_search_engine/models/se_index.py
+++ b/connector_search_engine/models/se_index.py
@@ -156,7 +156,11 @@ class SeIndex(models.Model):
             domain = []
         self.search(domain).recompute_all_binding()
 
-    def force_recompute_all_binding(self) -> None:
+    def recompute_and_export_all_binding(self) -> None:
+        # Note: when we force the binding to recompute,
+        # we cannot be sure that the previously computed value
+        # has been exported (since the record may have been in the 'to_export' state)
+        # and was forced to be recomputed, so we always force the export.
         self.recompute_all_binding(force_export=True)
 
     def recompute_all_binding(self, force_export: bool = False):

--- a/connector_search_engine/tests/test_all.py
+++ b/connector_search_engine/tests/test_all.py
@@ -118,9 +118,9 @@ class TestBindingIndex(TestBindingIndexBaseFake):
         self.assertEqual(self.partner_binding.state, "to_export")
         self.assertTrue(self.partner_binding.date_recomputed)
 
-    def test_force_recompute_all_binding(self):
+    def test_recompute_and_export_all_binding(self):
         with mock.patch.object(type(self.se_index), "recompute_all_binding") as mocked:
-            self.se_index.force_recompute_all_binding()
+            self.se_index.recompute_and_export_all_binding()
         mocked.assert_called_with(force_export=True)
 
     def test_force_batch_sync_with_not_exportable_binding(self):

--- a/connector_search_engine/views/se_index.xml
+++ b/connector_search_engine/views/se_index.xml
@@ -9,18 +9,18 @@
             <form>
                 <header>
                     <button
-                        name="force_recompute_all_binding"
+                        name="recompute_and_export_all_binding"
                         type="object"
-                        string="Recompute all binding"
+                        string="Recompute and Export all bindings"
                         icon="fa-gears"
-                        help="Force to recompute all binding of the index and set them to the state 'To update'"
+                        help="Force to recompute all bindings of the index and reexport all of them, even if there is no change"
                     />
                     <button
                         name="force_batch_sync"
                         type="object"
-                        string="Export all binding"
+                        string="Export all bindings"
                         icon="fa-upload"
-                        help="Force the export of all binding"
+                        help="Force the export of all bindings"
                     />
                     <button
                         name="export_settings"
@@ -161,8 +161,11 @@
                                 <div class="o_kanban_record_top">
                                     <div class="o_kanban_record_headings">
                                         <strong class="o_kanban_record_title">
-                                            <field name="model_id" />
+                                            <field name="name" />
                                         </strong>
+                                        <p>
+                                            <field name="model_id" />
+                                        </p>
                                         <p>
                                             <field name="lang_id" />
                                         </p>
@@ -192,21 +195,21 @@
                                             >Configuration
                                             </a>
                                             <a
-                                                name="force_recompute_all_binding"
+                                                name="recompute_and_export_all_binding"
                                                 role="menuitem"
                                                 class="dropdown-item"
-                                                help="Force to recompute all binding of the index and set them to the state 'To update'"
+                                                help="Force to recompute all bindings of the index and reexport all of them, even if there is no change"
                                                 icon="fa-gears"
                                                 type="object"
-                                            >Recompute all binding</a>
+                                            >Recompute and export all bindings</a>
                                             <a
                                                 name="force_batch_sync"
                                                 role="menuitem"
                                                 class="dropdown-item"
-                                                help="Force the export of all binding"
+                                                help="Force the export of all bindings"
                                                 icon="fa-upload"
                                                 type="object"
-                                            >Export all binding</a>
+                                            >Export all bindings</a>
                                             <a
                                                 name="export_settings"
                                                 role="menuitem"


### PR DESCRIPTION
connector_search_engine: fix migration ui and improve UI

- [x] The count (count_error, count_done...) where broken on the se.index (migration issue)
- [x] Improve UI when recomputing manually the binding and set the right state

@paradoxxxzero  @Kev-Roche 