### PR TITLE
Mention TypesenseKit for command-line checks

### DIFF
--- a/connector_typesense/readme/USAGE.md
+++ b/connector_typesense/readme/USAGE.md
@@ -2,3 +2,10 @@ We recommend to use the typesense-dashboard for managing your typesense
 server. I will allow you to configure the mapping of index with a nice
 UI. Please take a look here:
 <https://github.com/bfritscher/typesense-dashboard/releases>
+
+For command-line checks or CI workflows, you can also use TypesenseKit:
+
+```shell
+TYPESENSE_URL=http://localhost:8108 TYPESENSE_API_KEY=your_admin_key \
+  npm exec --yes --package @typesensekit/cli -- tsk collections.list --input '{}'
+```


### PR DESCRIPTION
Adds a small usage note for running command-line Typesense checks with TypesenseKit alongside the existing dashboard recommendation.

No tests run; README fragment only.