### PR TITLE
[DRAFT][FIX][18.0] connector_search_engine: issues when deleting Odoo records

### DIFF
--- a/connector_search_engine/models/se_binding.py
+++ b/connector_search_engine/models/se_binding.py
@@ -154,8 +154,9 @@ class SeBinding(models.Model):
             # Nothing to do
             return
         size = min(self.index_id.mapped("batch_exporting_size"))
-        self.write({"state": "recomputing"})
-        for binding in self.with_context(tracking_disable=True)._batch(size):
+        to_recompute = self.filtered(lambda b: b.state not in ("to_delete", "deleting"))
+        to_recompute.state = "recomputing"
+        for binding in to_recompute.with_context(tracking_disable=True)._batch(size):
             description = self.env._(
                 "Recompute %(name)s json and check if need update", name=self._name
             )

--- a/connector_search_engine/models/se_indexable_record.py
+++ b/connector_search_engine/models/se_indexable_record.py
@@ -170,12 +170,7 @@ class SeIndexableRecord(models.AbstractModel):
 
     def unlink(self):
         bindings = self.sudo()._get_bindings()
-        bindings.sudo().write(
-            {
-                "state": "to_delete",
-                "res_id": False,
-            }
-        )
+        bindings.sudo().state = "to_delete"
         return super().unlink()
 
     def write(self, vals):


### PR DESCRIPTION
1. When deleting more than 1 Odoo record at a time, it used to raise the _unique SQL constain_ `item_uniq_per_index`. This fix propose to keep `se_binding.res_id` to its original value to skip this raise.
2. Also, when by unfortunate chance the CRON `ir_cron_recompute_all_index` (every 24h by default) runs just before `ir_cron_export_binding` (every 5min by default), the 'to_delete' bindings are changed to 'to_recompute', which cancels the 'to_delete' order to the SE. This fix suggests to skip recomputing of 'to_delete' bindings to ensure they are well catched by the next run of `ir_cron_export_binding`.